### PR TITLE
Fix: TypeError: AsyncSession.request() got an unexpected keyword argument 'thread'

### DIFF
--- a/scrapy_impersonate/parser.py
+++ b/scrapy_impersonate/parser.py
@@ -92,10 +92,6 @@ class RequestParser:
     def verify(self) -> Optional[bool]:
         return self._impersonate_args.get("verify")
 
-    @property
-    def thread(self) -> Optional[str]:
-        return self._impersonate_args.get("thread")
-
     def as_dict(self) -> dict:
         return {
             property_name: getattr(self, property_name)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="scrapy-impersonate",
-    version="1.1.0b2",
+    version="1.1.1b2",
     author="Jalil SA (jxlil)",
     description="Scrapy download handler that can impersonate browser fingerprints",
     license="MIT",


### PR DESCRIPTION
The `thread` argument was removed because it's not supported by `AsyncSession`

closes https://github.com/jxlil/scrapy-impersonate/issues/3