### PR TITLE
Fix: Scrapy spider 3x slower after implementing this

### DIFF
--- a/scrapy_impersonate/handler.py
+++ b/scrapy_impersonate/handler.py
@@ -1,13 +1,12 @@
-from typing import Optional, Type, TypeVar
+from typing import Type, TypeVar
 
 from curl_cffi.requests import AsyncSession
-from scrapy import signals
 from scrapy.core.downloader.handlers.http import HTTPDownloadHandler
 from scrapy.crawler import Crawler
 from scrapy.http import Headers, Request, Response
 from scrapy.responsetypes import responsetypes
 from scrapy.spiders import Spider
-from scrapy.utils.defer import deferred_f_from_coro_f, deferred_from_coro
+from scrapy.utils.defer import deferred_f_from_coro_f
 from scrapy.utils.reactor import verify_installed_reactor
 from twisted.internet.defer import Deferred
 
@@ -22,26 +21,21 @@ class ImpersonateDownloadHandler(HTTPDownloadHandler):
         super().__init__(settings=settings, crawler=crawler)
 
         verify_installed_reactor("twisted.internet.asyncioreactor.AsyncioSelectorReactor")
-        crawler.signals.connect(self._engine_started, signals.engine_started)
-
-        self.client: Optional[AsyncSession] = None
 
     @classmethod
     def from_crawler(cls: Type[ImpersonateHandler], crawler: Crawler) -> ImpersonateHandler:
         return cls(crawler)
 
-    @deferred_f_from_coro_f
-    async def _engine_started(self, signal, sender) -> None:
-        self.client = await AsyncSession().__aenter__()
-
     def download_request(self, request: Request, spider: Spider) -> Deferred:
         if request.meta.get("impersonate"):
-            return deferred_from_coro(self._download_request(request, spider))
+            return self._download_request(request, spider)
 
         return super().download_request(request, spider)
 
+    @deferred_f_from_coro_f
     async def _download_request(self, request: Request, spider: Spider) -> Response:
-        response = await self.client.request(**RequestParser(request).as_dict())  # type: ignore
+        async with AsyncSession() as client:
+            response = await client.request(**RequestParser(request).as_dict())  # type: ignore
 
         headers = Headers(response.headers)
         headers.pop("Content-Encoding", None)
@@ -60,11 +54,3 @@ class ImpersonateDownloadHandler(HTTPDownloadHandler):
             flags=["impersonate"],
             request=request,
         )
-
-    def close(self):
-        yield super().close()
-        yield self._close()
-
-    @deferred_f_from_coro_f
-    async def _close(self) -> None:
-        await self.client.__aexit__()  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="scrapy-impersonate",
-    version="1.2.1",
+    version="1.2.2",
     author="Jalil SA (jxlil)",
     description="Scrapy download handler that can impersonate browser fingerprints",
     license="MIT",


### PR DESCRIPTION
scrapy-impersonate is now faster. The following tests were performed with a `CONCURRENT_REQUESTS` of 32 and 84 random websites:

Before:
```
scrapy crawl impersonate  3.57s user 0.64s system 29% cpu 14.467 total
```

After:
```
scrapy crawl impersonate  2.32s user 0.48s system 52% cpu 5.323 total
```

Closes https://github.com/jxlil/scrapy-impersonate/issues/10