### PR TITLE
Fix multi-header compatibility with Scrapy

### DIFF
--- a/scrapy_impersonate/handler.py
+++ b/scrapy_impersonate/handler.py
@@ -37,7 +37,7 @@ class ImpersonateDownloadHandler(HTTPDownloadHandler):
         async with AsyncSession() as client:
             response = await client.request(**RequestParser(request).as_dict())  # type: ignore
 
-        headers = Headers(response.headers)
+        headers = Headers(response.headers.multi_items())
         headers.pop("Content-Encoding", None)
 
         respcls = responsetypes.from_args(


### PR DESCRIPTION
`ImpersonateDownloadHandler._download_request()` currently returns a `scrapy.http.Response` where multiple headers with the same key are concatenated into a single comma separated value. This means that for example, `response.cookies.getlist('Set-Cookie')` returns a list with 1 item even if multiple `Set-Cookie` headers were present in the HTTP response.

To be compatible with Scrapy's built-in `HTTP11DownloadHandler` and `H2DownloadHandler`, `response.cookies.getlist(key)` should return _multiple_ values when multiple headers with the same `key` are present in the HTTP response.

To fix this, we can pass [`curl_cffi.requests.Headers.multi_items()`](https://curl-cffi.readthedocs.io/en/latest/api.html#curl_cffi.requests.Headers.multi_items) to Scrapy's `Headers()` constructor.