### PR TITLE
Fix/proxy auth

### DIFF
--- a/scrapy_impersonate/parser.py
+++ b/scrapy_impersonate/parser.py
@@ -1,8 +1,6 @@
-import base64
-from typing import Optional, Tuple, Union
-from urllib.parse import urlparse
-from curl_cffi import CurlHttpVersion
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+from curl_cffi import CurlHttpVersion, CurlMime
 from scrapy.http import Request
 
 
@@ -12,16 +10,29 @@ class RequestParser:
         self._impersonate_args = request.meta.get("impersonate_args", {})
 
     @property
-    def url(self) -> str:
-        return self._request.url
-
-    @property
     def method(self) -> str:
         return self._request.method
 
     @property
-    def data(self) -> Union[bytes, str, None]:
+    def url(self) -> str:
+        return self._request.url
+
+    @property
+    def params(self) -> Optional[Union[Dict, List, Tuple]]:
+        return self._impersonate_args.get("params")
+
+    @property
+    def data(self) -> Optional[Any]:
         return self._request.body
+
+    @property
+    def json(self) -> Optional[dict]:
+        return self._impersonate_args.get("json")
+
+    @property
+    def headers(self) -> dict:
+        headers = self._request.headers.to_unicode_dict()
+        return dict(headers)
 
     @property
     def cookies(self) -> dict:
@@ -36,46 +47,8 @@ class RequestParser:
             return {}
 
     @property
-    def headers(self) -> dict:
-        headers = self._request.headers.to_unicode_dict()
-        return dict(headers)
-
-    @property
-    def proxies(self) -> Union[dict, None]:
-        proxy = self._request.meta.get("proxy")
-        if not proxy:
-            return
-
-        parsed_proxy = urlparse(proxy)
-
-        proxy_scheme = parsed_proxy.scheme or "http"
-        proxy_netloc = parsed_proxy.netloc or parsed_proxy.path
-
-        if proxy_auth := self.headers.get("Proxy-Authorization"):
-            proxy_auth = proxy_auth.replace("Basic", "").strip()
-            proxy_auth = base64.b64decode(proxy_auth).decode()
-
-            if "@" not in proxy_netloc:
-                proxy_netloc = f"{proxy_auth}@{proxy_netloc}"
-
-        proxy = f"{proxy_scheme}://{proxy_netloc}"
-        return {"http": proxy, "https": proxy}
-
-    @property
-    def allow_redirects(self) -> bool:
-        return False if self._request.meta.get("dont_redirect") else True
-
-    @property
-    def impersonate(self) -> Union[str, None]:
-        return self._request.meta.get("impersonate")
-
-    @property
-    def params(self) -> Optional[dict]:
-        return self._impersonate_args.get("params")
-
-    @property
-    def json(self) -> Optional[dict]:
-        return self._impersonate_args.get("json")
+    def files(self) -> Optional[dict]:
+        return self._impersonate_args.get("files")
 
     @property
     def auth(self) -> Optional[Tuple[str, str]]:
@@ -83,19 +56,79 @@ class RequestParser:
 
     @property
     def timeout(self) -> Union[float, Tuple[float, float]]:
-        return self._impersonate_args.get("timeout", 30)
+        return self._impersonate_args.get("timeout", 30.0)
+
+    @property
+    def allow_redirects(self) -> bool:
+        return False if self._request.meta.get("dont_redirect") else True
 
     @property
     def max_redirects(self) -> int:
         return self._impersonate_args.get("max_redirects", -1)
 
     @property
+    def proxies(self) -> Optional[dict]:
+        return self._impersonate_args.get("proxies")
+
+    @property
+    def proxy(self) -> Optional[str]:
+        return self._request.meta.get("proxy")
+
+    @property
+    def proxy_auth(self) -> Optional[Tuple[str, str]]:
+        return self._impersonate_args.get("proxy_auth")
+
+    @property
     def verify(self) -> Optional[bool]:
         return self._impersonate_args.get("verify")
 
     @property
+    def referer(self) -> Optional[str]:
+        return self._impersonate_args.get("referer")
+
+    @property
+    def accept_encoding(self) -> str:
+        return self._impersonate_args.get("accept_encoding", "gzip, deflate, br")
+
+    @property
+    def content_callback(self) -> Optional[Callable]:
+        return self._impersonate_args.get("content_callback")
+
+    @property
+    def impersonate(self) -> Optional[str]:
+        return self._request.meta.get("impersonate")
+
+    @property
+    def default_headers(self) -> Optional[bool]:
+        return self._impersonate_args.get("default_headers")
+
+    @property
+    def default_encoding(self) -> Union[str, Callable[[bytes], str]]:
+        return self._impersonate_args.get("default_encoding", "utf-8")
+
+    @property
     def http_version(self) -> Optional[CurlHttpVersion]:
         return self._impersonate_args.get("http_version")
+
+    @property
+    def interface(self) -> Optional[str]:
+        return self._impersonate_args.get("interface")
+
+    @property
+    def cert(self) -> Optional[Union[str, Tuple[str, str]]]:
+        return self._impersonate_args.get("cert")
+
+    @property
+    def stream(self) -> bool:
+        return self._impersonate_args.get("stream", False)
+
+    @property
+    def max_recv_speed(self) -> int:
+        return self._impersonate_args.get("max_recv_speed", 0)
+
+    @property
+    def multipart(self) -> Optional[CurlMime]:
+        return self._impersonate_args.get("multipart")
 
     def as_dict(self) -> dict:
         return {

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="scrapy-impersonate",
-    version="1.2.3",
+    version="1.2.4",
     author="Jalil SA (jxlil)",
     description="Scrapy download handler that can impersonate browser fingerprints",
     license="MIT",


### PR DESCRIPTION
Now `RequestParser` does not handle proxy authentication, this is to be able to use custom authentications:

```python
yield Request(
            url=f"http://example.com",
            headers={
                "Proxy-Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyX2lkIiwiZXhwIjowMDAwMDAwMDAwfQ.8ZLkrPvu9-hKLnq8fghbZYdv-a-KMJfHtSndfFmT3PQ",
            },
            meta={
                "impersonate": "chrome110",
                "proxy": "http://0.0.0.0:80000",
            },
        )
```

```python
yield Request(
            url=f"http://example.com",
            meta={
                "impersonate": "chrome110",
                "proxy": "http://0.0.0.0:80000",
                "impersonate_args": {
                    "proxy_auth": ("user", "passw"),
                },
            },
        )
```

Closes https://github.com/jxlil/scrapy-impersonate/issues/13