### PR TITLE
Refactor RequestParser and curl_options

### DIFF
--- a/scrapy_impersonate/handler.py
+++ b/scrapy_impersonate/handler.py
@@ -35,8 +35,9 @@ class ImpersonateDownloadHandler(HTTPDownloadHandler):
     @deferred_f_from_coro_f
     async def _download_request(self, request: Request, spider: Spider) -> Response:
         curl_options = CurlOptionsParser(request).as_dict()
-        async with AsyncSession(max_clients=1,curl_options=curl_options) as client:
-            response = await client.request(**RequestParser(request).as_dict())  # type: ignore
+        async with AsyncSession(max_clients=1, curl_options=curl_options) as client:
+            request_args = RequestParser(request).as_dict()
+            response = await client.request(**request_args)
 
         headers = Headers(response.headers.multi_items())
         headers.pop("Content-Encoding", None)

--- a/scrapy_impersonate/parser.py
+++ b/scrapy_impersonate/parser.py
@@ -18,8 +18,7 @@ class CurlOptionsParser:
     def _set_proxy_auth(self):
         """Add support for proxy auth headers"""
 
-        proxy_authorization = self.request.headers.pop(b'Proxy-Authorization', "")
-        if proxy_authorization:
+        if proxy_authorization := self.request.headers.pop(b"Proxy-Authorization", None):
             proxy_header = [b"Proxy-Authorization: " + proxy_authorization[0]]
             self.curl_options[CurlOpt.PROXYHEADER] = proxy_header
 
@@ -33,6 +32,8 @@ class CurlOptionsParser:
 
 
 class RequestParser:
+    # TODO: Implement @request_arg_method instead of @property
+
     def __init__(self, request: Request) -> None:
         self._request = request
         self._impersonate_args = request.meta.get("impersonate_args", {})
@@ -54,10 +55,6 @@ class RequestParser:
         return self._request.body
 
     @property
-    def json(self) -> Optional[dict]:
-        return self._impersonate_args.get("json")
-
-    @property
     def headers(self) -> dict:
         headers = self._request.headers.to_unicode_dict()
         return dict(headers)
@@ -75,92 +72,23 @@ class RequestParser:
             return {}
 
     @property
-    def files(self) -> Optional[dict]:
-        return self._impersonate_args.get("files")
-
-    @property
-    def auth(self) -> Optional[Tuple[str, str]]:
-        return self._impersonate_args.get("auth")
-
-    @property
-    def timeout(self) -> Union[float, Tuple[float, float]]:
-        return self._impersonate_args.get("timeout", 30.0)
-
-    @property
     def allow_redirects(self) -> bool:
         return False if self._request.meta.get("dont_redirect") else True
-
-    @property
-    def max_redirects(self) -> int:
-        return self._impersonate_args.get("max_redirects", -1)
-
-    @property
-    def proxies(self) -> Optional[dict]:
-        return self._impersonate_args.get("proxies")
 
     @property
     def proxy(self) -> Optional[str]:
         return self._request.meta.get("proxy")
 
     @property
-    def proxy_auth(self) -> Optional[Tuple[str, str]]:
-        return self._impersonate_args.get("proxy_auth")
-
-    @property
-    def verify(self) -> Optional[bool]:
-        return self._impersonate_args.get("verify")
-
-    @property
-    def referer(self) -> Optional[str]:
-        return self._impersonate_args.get("referer")
-
-    @property
-    def accept_encoding(self) -> str:
-        return self._impersonate_args.get("accept_encoding", "gzip, deflate, br")
-
-    @property
-    def content_callback(self) -> Optional[Callable]:
-        return self._impersonate_args.get("content_callback")
-
-    @property
     def impersonate(self) -> Optional[str]:
         return self._request.meta.get("impersonate")
 
-    @property
-    def default_headers(self) -> Optional[bool]:
-        return self._impersonate_args.get("default_headers")
-
-    @property
-    def default_encoding(self) -> Union[str, Callable[[bytes], str]]:
-        return self._impersonate_args.get("default_encoding", "utf-8")
-
-    @property
-    def http_version(self) -> Optional[CurlHttpVersion]:
-        return self._impersonate_args.get("http_version")
-
-    @property
-    def interface(self) -> Optional[str]:
-        return self._impersonate_args.get("interface")
-
-    @property
-    def cert(self) -> Optional[Union[str, Tuple[str, str]]]:
-        return self._impersonate_args.get("cert")
-
-    @property
-    def stream(self) -> bool:
-        return self._impersonate_args.get("stream", False)
-
-    @property
-    def max_recv_speed(self) -> int:
-        return self._impersonate_args.get("max_recv_speed", 0)
-
-    @property
-    def multipart(self) -> Optional[CurlMime]:
-        return self._impersonate_args.get("multipart")
-
     def as_dict(self) -> dict:
-        return {
+        request_args = {
             property_name: getattr(self, property_name)
             for property_name, method in self.__class__.__dict__.items()
             if isinstance(method, property)
         }
+
+        request_args.update(self._impersonate_args)
+        return request_args

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="scrapy-impersonate",
-    version="1.3.1",
+    version="1.4.0",
     author="Jalil SA (jxlil)",
     description="Scrapy download handler that can impersonate browser fingerprints",
     license="MIT",


### PR DESCRIPTION
- Adding `CurlOptionsParser` to facilitate handling of `curl_options`
- Updated RequestParser can now send any argument from `impersonate_args`