### PR TITLE
chore(parser): add SSL verification option

### DIFF
--- a/scrapy_impersonate/parser.py
+++ b/scrapy_impersonate/parser.py
@@ -80,6 +80,10 @@ class RequestParser:
         return self._request.meta.get("proxy")
 
     @property
+    def verify(self) -> bool:
+        return self._request.meta.get("verify", True)
+
+    @property
     def impersonate(self) -> Optional[str]:
         return self._request.meta.get("impersonate")
 


### PR DESCRIPTION
By default, `curl_cffi` always verifies SSL certificate, this change allows to disable SSL verification.