### PR TITLE
Fix: SOCKS Proxy Support

### DIFF
--- a/scrapy_impersonate/parser.py
+++ b/scrapy_impersonate/parser.py
@@ -25,7 +25,7 @@ class CurlOptionsParser:
                 if proxy_authorization:
                     proxy_header = [b"Proxy-Authorization: " + proxy_authorization[0]]
                     self.curl_options[CurlOpt.PROXYHEADER] = proxy_header
-            elif proxy.startswith("socks5://") or proxy.startswith("socks4://"):
+            elif proxy.startswith("socks5h://") or proxy.startswith("socks5://") or proxy.startswith("socks4://"):
                 # For SOCKS5 proxy authentication, we need to extract the username and password
                 auth = self.request.headers.pop(b"Proxy-Authorization", None)
                 if auth:

--- a/scrapy_impersonate/parser.py
+++ b/scrapy_impersonate/parser.py
@@ -32,7 +32,7 @@ class CurlOptionsParser:
                     username,password = base64.b64decode(auth[0].split(b" ")[1]).split(b":")
                     self.curl_options[CurlOpt.PROXYUSERNAME] = username
                     self.curl_options[CurlOpt.PROXYPASSWORD] = password
-                    self.curl_options[CurlOpt.SOCKS5_AUTH] = ctypes.c_ulong(0x01).value
+
                     
     def as_dict(self):
         for method_name in dir(self):


### PR DESCRIPTION
Previously, authentication information for SOCKS proxies (such as socks5, socks5h, and socks4) was not correctly extracted and set in the curl options, causing proxy authentication to fail.

For HTTP/HTTPS proxies, the authentication is handled differently: the Proxy-Authorization header is passed directly using the PROXYHEADER curl option. With this fix, now supports SOCKS proxy authentication as expected.


