### PR TITLE
ImpersonateDownloadHandler download_request fix for Scrapy 2.14

### DIFF
--- a/scrapy_impersonate/handler.py
+++ b/scrapy_impersonate/handler.py
@@ -46,7 +46,7 @@ class ImpersonateDownloadHandler(HTTPDownloadHandler):
             return super().download_request(request)
 
     @deferred_f_from_coro_f
-    async def _download_request(self, request: Request, spider: Spider) -> Response:
+    async def _download_request(self, request: Request) -> Response:
         curl_options = CurlOptionsParser(request.copy()).as_dict()
 
         async with AsyncSession(max_clients=1, curl_options=curl_options) as client:

--- a/scrapy_impersonate/handler.py
+++ b/scrapy_impersonate/handler.py
@@ -35,9 +35,15 @@ class ImpersonateDownloadHandler(HTTPDownloadHandler):
 
     def download_request(self, request: Request, spider: Spider) -> Deferred:
         if request.meta.get("impersonate"):
-            return self._download_request(request, spider)
+            try:
+                return self._download_request(request, spider)
+            except TypeError:
+                return self._download_request(request)
 
-        return super().download_request(request, spider)
+        try:
+            return super().download_request(request, spider)
+        except TypeError:
+            return super().download_request(request)
 
     @deferred_f_from_coro_f
     async def _download_request(self, request: Request, spider: Spider) -> Response:

--- a/scrapy_impersonate/handler.py
+++ b/scrapy_impersonate/handler.py
@@ -35,10 +35,7 @@ class ImpersonateDownloadHandler(HTTPDownloadHandler):
 
     def download_request(self, request: Request, spider: Spider) -> Deferred:
         if request.meta.get("impersonate"):
-            try:
-                return self._download_request(request, spider)
-            except TypeError:
-                return self._download_request(request)
+            return self._download_request(request)
 
         try:
             return super().download_request(request, spider)


### PR DESCRIPTION
Scrapy 2.14.x has changed its HTTPDownloadHandler.download_request method signature to not include the spider parameter.  Adding except block to catch TypeError and use the updated download_request method - used the technique in the ImpersonateDownloadHandler constructor as inspiration.