### PR TITLE
fix: coroutine object has no attribute asfuture

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 curl-cffi>=0.13.0
-scrapy>=2.12.0
+scrapy>=2.13.0

--- a/scrapy_impersonate/handler.py
+++ b/scrapy_impersonate/handler.py
@@ -10,10 +10,7 @@ from scrapy.http.headers import Headers
 from scrapy.http.request import Request
 from scrapy.http.response import Response
 from scrapy.responsetypes import responsetypes
-from scrapy.spiders import Spider
-from scrapy.utils.defer import deferred_f_from_coro_f
 from scrapy.utils.reactor import verify_installed_reactor
-from twisted.internet.defer import Deferred
 
 from scrapy_impersonate.parser import CurlOptionsParser, RequestParser
 
@@ -33,16 +30,11 @@ class ImpersonateDownloadHandler(HTTPDownloadHandler):
     def from_crawler(cls: Type[ImpersonateHandler], crawler: Crawler) -> ImpersonateHandler:
         return cls(crawler)
 
-    def download_request(self, request: Request, spider: Spider) -> Deferred:
+    async def download_request(self, request: Request) -> Response:
         if request.meta.get("impersonate"):
-            return self._download_request(request)
+            return await self._download_request(request)
+        return await super().download_request(request)
 
-        try:
-            return super().download_request(request, spider)
-        except TypeError:
-            return super().download_request(request)
-
-    @deferred_f_from_coro_f
     async def _download_request(self, request: Request) -> Response:
         curl_options = CurlOptionsParser(request.copy()).as_dict()
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="scrapy-impersonate",
-    version="1.6.3",
+    version="1.6.4",
     author="Jalil SA (jxlil)",
     description="Scrapy download handler that can impersonate browser fingerprints",
     license="MIT",


### PR DESCRIPTION
Migrates `ImpersonateDownloadHandler.download_request` from the legacy Deferred-returning API to Scrapy's new async API (async def, single request argument).